### PR TITLE
Problem mit Zeilenumbrüchen in Kommentaren und falschem Feldnamen

### DIFF
--- a/divera.py
+++ b/divera.py
@@ -28,13 +28,18 @@ def convertToUnixTs(string : str) -> int:
     dt = datetime.strptime(string, '%Y-%m-%dT%H:%M:%S')
     return int(dt.strftime('%s'))
 
+
 def setDataDivera(id, data):
     payload = {
         'status' : FMSSTEIN[data['status']],
         'status_id' : FMSSTEIN[data['status']]
     }
     if data['comment']:
-        payload.update({'fmsstatus_note' : data['comment']})
+        comment_without_linebreaks = data['comment'].replace('\n', ' ')  # Replace line breaks with spaces
+        print("Comment: %s" % (comment_without_linebreaks))
+        payload.update({'status_note' : comment_without_linebreaks})
+
+    print("Payload: ", payload)
 
     r = requests.post(URL + "using-vehicles/set-status/" + str(id) + "?accesskey=" + config['divera']['accesskey'], json=payload)
     r.raise_for_status()

--- a/divera.py
+++ b/divera.py
@@ -36,10 +36,7 @@ def setDataDivera(id, data):
     }
     if data['comment']:
         comment_without_linebreaks = data['comment'].replace('\n', ' ')  # Replace line breaks with spaces
-        print("Comment: %s" % (comment_without_linebreaks))
         payload.update({'status_note' : comment_without_linebreaks})
-
-    print("Payload: ", payload)
 
     r = requests.post(URL + "using-vehicles/set-status/" + str(id) + "?accesskey=" + config['divera']['accesskey'], json=payload)
     r.raise_for_status()


### PR DESCRIPTION
In der Funktion setDataDivera gibt es zwei Probleme:

Zeilenumbrüche in Kommentaren verursachen Probleme mit der Divera API. Diese sollten durch Leerzeichen ersetzt werden, bevor sie an die API gesendet werden.
Der Feldname 'fmsstatus_note' wird verwendet, um den Kommentar an die Divera API zu senden. Laut API-Dokumentation (https://api.divera247.com/?urls.primaryName=api%2Fv2%2Fusing-vehicle) ist der korrekte Feldname jedoch 'status_note'.