### PR TITLE
Sleep wait enhancement

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,14 +18,14 @@ pip3 install "httpx[http2]"
 ```
 
 ## Einrichtung
-1. Voarb: Zunächst werden je ein Nutzer in Stein.APP und Divera 24/7 benötigt.
+1. Vorab: Zunächst werden je ein Nutzer in Stein.APP und Divera 24/7 benötigt.
     1. Divera 24/7: Im Menüpunkt Verwaltung -> Schnittstellen -> System-Benutzer muss ein neuer System-Benutzer angelegt werden. Der dabei generierte Accesskey wird gleich benötigt.
     1. Stein.APP: Es wird ein "techuser" benötigt. Also einen neuen Nutzer mit dem Häckchen "Für Nutzung über API".
 1. Damit die Fahrzeuge in Stein denen in Divera 24/7 zugeordnet werden können, wird das Feld Kennzeichen genutzt. Daher müssen sowohl in Stein als auch in Divera 24/7 die Kennzeichen gepflegt und identisch sein. 
 1. Kopiere config.json.sample nach config.json
 1. Editieren von config.json
     1. Divera: Unter "accesskey" den vorher generierten Accesskey eintragen.
-    1. Stein: Hier den API KEy des angelegten Benutzers eintragen. Unter "buname" wird die ID der Organisationseinheit eingetragen. Dies ist der Name des OVs ohne Dienststellenkürzel. Also "671" für OV Siegburg.
+    1. Stein: Hier den API KEy des angelegten Benutzers eintragen. Unter "buname" wird die ID der Organisationseinheit eingetragen. Dies ist der Name des OVs ohne Dienststellenkürzel. Also "671" für OV Siegburg. Die ID des eigenen OV kann man leicht über die URL auf der Stein Webseite in Erfahrung bringen, wenn man zur eigenen Organisationseinheit navigiert. Beim Beispiel OV Siegburg wäre dies https://stein.app/dashboard/bu/671/
 1. Anschließend das script divera.py aufrufen. 
 
 ## Docker

--- a/config.json.sample
+++ b/config.json.sample
@@ -5,5 +5,6 @@
     "stein" : {
         "buname" : "your_BU_ID",
 	"apikey" : "your_api_key"
-    }
+    },
+    "sleep" : 0
 }

--- a/divera.py
+++ b/divera.py
@@ -8,6 +8,7 @@ import argparse
 import json
 import logging
 import sys
+import time
 
 URL = "https://app.divera247.com/api/v2/"
 
@@ -119,3 +120,8 @@ if __name__ == "__main__":
                 s.update_asset(data_stein['id'], payload)
         else:
             logging.info("Eintrag unverändert")
+    
+    sleep_minutes = config.get("sleep")   # Optionaler Sleep am Ende (in Minuten)
+    if isinstance(sleep_minutes, int) and sleep_minutes > 0:
+        logging.info(f"Sleep aktiviert: Warte {sleep_minutes} Minuten vor Beenden...")
+        time.sleep(sleep_minutes * 60)


### PR DESCRIPTION
I took the liberty to make a small update to the README and added a "new feature" that introduces a configurable wait period (sleep) before the container exits.

Details:
- README.md – Added a hint on how to determine the ID of an Organisationseinheit.
- README.md – Fixed a minor typo.
- config.json.sample – Added a sleep variable (default: 0).
- divera.py – Added a conditional block at the end of the script. If the 'sleep' config value is set and greater than 0, the script will pause for the specified number of minutes before exiting. Also added the required import time.

Rationale for the sleep feature:
In my setup, I manage Docker containers fully automatically (including automated GHCR builds) using Portainer stacks. In the current release version, this leads to an undesired loop: the container is restarted immediately after finishing. To prevent this, I introduced a configurable sleep timer at the end of the script. This ensures the container remains running for a defined period before exiting (and being automatically restarted). In my case, I chose a 15-minute delay, effectively throttling the re-run interval of the status sync.